### PR TITLE
Protocol relative links in YouTube fake response

### DIFF
--- a/Lib/Embera/Providers/Youtube.php
+++ b/Lib/Embera/Providers/Youtube.php
@@ -44,7 +44,7 @@ class Youtube extends \Embera\Adapters\Service
             'provider_name' => 'Youtube',
             'provider_url' => 'http://www.youtube.com',
             'title' => 'Unknown title',
-            'html' => '<iframe width="{width}" height="{height}" src="http://www.youtube.com/embed/' . $matches['1'] . '" frameborder="0" allowfullscreen></iframe>',
+            'html' => '<iframe width="{width}" height="{height}" src="//www.youtube.com/embed/' . $matches['1'] . '" frameborder="0" allowfullscreen></iframe>',
         );
     }
 }


### PR DESCRIPTION
This would provide supporting for embedding on https but only for YouTube fake responses for now!

This could probably be done for other providers as well but for now I just know that youtube embeds work over https...