### PR TITLE
Instagram changed their response object

### DIFF
--- a/Lib/Embera/Providers/Instagram.php
+++ b/Lib/Embera/Providers/Instagram.php
@@ -32,7 +32,7 @@ class Instagram extends \Embera\Adapters\Service
     /** inline {@inheritdoc} */
     protected function modifyResponse(array $response = array())
     {
-        $extension = strtolower(pathinfo(parse_url($response['url'],PHP_URL_PATH),PATHINFO_EXTENSION));
+        $extension = strtolower(pathinfo(parse_url($response['provider_url'],PHP_URL_PATH),PATHINFO_EXTENSION));
         if (empty($response['html']) && in_array($extension, array('jpg', 'jpeg', 'png', 'gif'))) {
             $html  = '<a href="' . $response['url'] . '" target="_blank">';
             $html .= '<img class="instagram-oembed" src="' . $response['url'] . '" width="' . $response['width'] . '" height="' . $response['height'] . '" alt="' . htmlspecialchars($response['title'], ENT_QUOTES, 'UTF-8') . '" title="' . htmlspecialchars($response['title'], ENT_QUOTES, 'UTF-8') . '">';


### PR DESCRIPTION
$response['url'] threw a fatal error. The key apparantly changed from "url" to "provider_url".