### PR TITLE
Fix tests on IFixIt embeds after change in embed HTML

### DIFF
--- a/Lib/Embera/Providers/IFixIt.php
+++ b/Lib/Embera/Providers/IFixIt.php
@@ -36,7 +36,7 @@ class IFixIt extends \Embera\Adapters\Service
             'type' => 'rich',
             'provider_name' => 'iFixit',
             'provider_url' => 'http://www.ifixit.com',
-            'html' => '<script type="text/javascript" src="http://d1luk0418egahw.cloudfront.net/static/embed/ifixit-embed.3.js?id=' . $matches['1'] . '"></script>',
+            'html' => '<iframe src="https://www.ifixit.com/Guide/Embed/'.$matches[1].'" width="1000" height="730" allowfullscreen frameborder="0"></iframe>\n',
         );
     }
 }

--- a/Tests/TestServiceIFixIt.php
+++ b/Tests/TestServiceIFixIt.php
@@ -31,7 +31,7 @@ class TestServiceIFixIt extends TestProviders
         ),
         'fake' => array(
             'type' => 'rich',
-            'html' => '<script'
+            'html' => '<iframe'
         )
     );
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,9 @@
         </testsuite>
     </testsuites>
     <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">Lib/</directory>
+        </whitelist>
         <blacklist>
             <directory suffix=".php">vendor/</directory>
             <directory suffix=".php">Tests/</directory>


### PR DESCRIPTION
Tests on master branch are currently failing.
```
$ phpunit --filter=TestServiceIFixIt
PHPUnit 5.2.9 by Sebastian Bergmann and contributors.

F.                                                                  2 / 2 (100%)

Time: 2.19 seconds, Memory: 29.25Mb

There was 1 failure:

1) TestServiceIFixIt::testProvider
Response is not <iframe in http://www.ifixit.com/Guide/Replacing+iPad+4+CDMA+Logic+Board/16458
Failed asserting that '<script type="text/javascript" src="http://d1luk0418egahw.cloudfront.net/static/embed/ifixit-embed.3.js?id=16458"></script>' contains "<iframe".

/Embera/Tests/TestProviders.php:162
/Embera/Tests/TestProviders.php:78
/Embera/Tests/TestServiceIFixIt.php:38

FAILURES!
Tests: 2, Assertions: 10, Failures: 1.

Generating code coverage report in HTML format ... done
```

The HTML has changed. The script tag has been replaced by an iframe.

Example: https://fr.ifixit.com/Embed?url=http%3A%2F%2Ffr.ifixit.com%2FGuide%2FiPad%2B4%2BCDMA%2BLogic%2BBoard%2BReplacement%2F16458&format=json

