### PR TITLE
Feature retain parameters

### DIFF
--- a/Lib/Embera/Adapters/Service.php
+++ b/Lib/Embera/Adapters/Service.php
@@ -23,6 +23,9 @@ abstract class Service
      */
     protected $url;
 
+    /** @var mixes Additional Parameters from the Original URL to be appended to the iframe src **/
+    protected $parameters;
+
     /** @var object Instance of \Embera\Oembed */
     protected $oembed = null;
 

--- a/Lib/Embera/Adapters/Service.php
+++ b/Lib/Embera/Adapters/Service.php
@@ -91,7 +91,8 @@ abstract class Service
         try {
 
             if ($res = $this->oembed->getResourceInfo($this->config['oembed'], $this->apiUrl, (string) $this->url, $this->config['params'])) {
-                return $this->modifyResponse($res);
+                $res = $this->modifyResponse($res);
+                return $this->appendParametersToResponse($res);
             }
 
         } catch (\Exception $e) {
@@ -104,7 +105,8 @@ abstract class Service
          */
         if (!$this->config['oembed'] && $response = $this->fakeResponse()) {
             $fakeResponse = new \Embera\FakeResponse($this->config, $response);
-            return $this->modifyResponse($fakeResponse->buildResponse());
+            $res = $this->modifyResponse($fakeResponse->buildResponse());
+            return $this->appendParametersToResponse($res);
         }
 
         return array();
@@ -188,6 +190,26 @@ abstract class Service
      */
     protected function modifyResponse(array $response = array())
     {
+        return $response;
+    }
+
+    /**
+     * Gives the ability to modify the response/fake-response array
+     * from an oembed provider.
+     *
+     * It should be overwritten by the service when needed
+     *
+     * @param array $response
+     * @return array
+     */
+    protected function appendParametersToResponse(array $response = array())
+    {
+        if( $this->parameters ){
+            preg_match('~(src="[^\"]+)(")~', $response['html'], $m);
+            if( strpos($m[1], '?')===false )
+                $this->parameters = '?'.substr($this->parameters, 1);
+            $response['html'] = preg_replace('~(<iframe[^>]+src="[^\"]+)(")~', '$1'.$this->parameters.'$2', $response['html']);
+        }
         return $response;
     }
 }

--- a/Lib/Embera/Embera.php
+++ b/Lib/Embera/Embera.php
@@ -108,7 +108,7 @@ class Embera
             $table = array();
             foreach ($data as $url => $service) {
                 if (!empty($service['html'])) {
-                    $table[$url] = sprintf( $outputWrapper , strtolower( $service['provider_name'] ) , $service['type'] , $service['html'] );
+                    $table[$url] = sprintf( $this->outputWrapper , strtolower( $service['provider_name'] ) , $service['type'] , $service['html'] );
                 }
             }
 

--- a/Lib/Embera/Embera.php
+++ b/Lib/Embera/Embera.php
@@ -38,6 +38,9 @@ class Embera
     /** @var string The pattern used to extract urls from a text when the embed:// prefix option is enabled */
     protected $urlEmbedRegex = '~\bembed://[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|/|_))~i';
 
+    /** @var string The pattern used to extract urls from a text when the embed:// prefix option is enabled */
+    protected $outputWrapper = '<div class="embera provider-%s type-%s">%s</div>';
+
     /**
      * Constructs the object and also instantiates the \Embera\Oembed Object
      * and stores it into the $oembed properoty
@@ -105,7 +108,7 @@ class Embera
             $table = array();
             foreach ($data as $url => $service) {
                 if (!empty($service['html'])) {
-                    $table[$url] = $service['html'];
+                    $table[$url] = sprintf( $outputWrapper , strtolower( $service['provider_name'] ) , $service['type'] , $service['html'] );
                 }
             }
 

--- a/Lib/Embera/HttpRequest.php
+++ b/Lib/Embera/HttpRequest.php
@@ -84,6 +84,7 @@ class HttpRequest
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_HEADER] = true;
         $options[CURLOPT_RETURNTRANSFER] = 1;
+        $options[CURLOPT_SSL_VERIFYPEER] = false;
 
          // CURLOPT_FOLLOWLOCATION doesnt play well with open_basedir/safe_mode
         if (ini_get('safe_mode') || ini_get('open_basedir')) {

--- a/Lib/Embera/Providers/Youtube.php
+++ b/Lib/Embera/Providers/Youtube.php
@@ -29,8 +29,9 @@ class Youtube extends \Embera\Adapters\Service
     /** inline {@inheritdoc} */
     protected function normalizeUrl()
     {
-        if (preg_match('~(?:v=|youtu\.be/|youtube\.com/embed/)([a-z0-9_-]+)~i', $this->url, $matches)) {
+        if (preg_match('~(?:v=|youtu\.be/|youtube\.com/embed/)([a-z0-9_-]+)([?&].+)?~i', $this->url, $matches)) {
             $this->url = new \Embera\Url('http://www.youtube.com/watch?v=' . $matches[1]);
+            $this->parameters = ( $matches[2] ? str_replace( '?' , '&' , $matches[2] ) : '' );
         }
     }
 
@@ -46,6 +47,16 @@ class Youtube extends \Embera\Adapters\Service
             'title' => 'Unknown title',
             'html' => '<iframe width="{width}" height="{height}" src="//www.youtube.com/embed/' . $matches['1'] . '" frameborder="0" allowfullscreen></iframe>',
         );
+    }
+
+    public function modifyResponse($response){
+      if( $this->parameters ){
+        preg_match('~(src="[^\"]+)(")~', $response['html'], $m);
+        if( strpos($m[1], '?')===false )
+          $this->parameters = '?'.substr($this->parameters, 1);
+        $response['html'] = preg_replace('~(src="[^\"]+)(")~', '$1'.$this->parameters.'$2', $response['html']);
+      }
+      return $response;
     }
 }
 

--- a/Lib/Embera/Providers/Youtube.php
+++ b/Lib/Embera/Providers/Youtube.php
@@ -48,16 +48,6 @@ class Youtube extends \Embera\Adapters\Service
             'html' => '<iframe width="{width}" height="{height}" src="//www.youtube.com/embed/' . $matches['1'] . '" frameborder="0" allowfullscreen></iframe>',
         );
     }
-
-    public function modifyResponse($response){
-      if( $this->parameters ){
-        preg_match('~(src="[^\"]+)(")~', $response['html'], $m);
-        if( strpos($m[1], '?')===false )
-          $this->parameters = '?'.substr($this->parameters, 1);
-        $response['html'] = preg_replace('~(src="[^\"]+)(")~', '$1'.$this->parameters.'$2', $response['html']);
-      }
-      return $response;
-    }
 }
 
 ?>


### PR DESCRIPTION
Allows parameters from the original URL to be retained and appended to the src attribute of the oembed iframe.

Handy for things like YouTube's "_autoplay_", "_rel_" and other player parameters.