### PR TITLE
Infogram now use infogram.com instead of infogr.am

### DIFF
--- a/Lib/Embera/Providers.php
+++ b/Lib/Embera/Providers.php
@@ -93,6 +93,7 @@ class Providers
         'ifttt.com' => '\Embera\Providers\IFTTT',
         '*.indacolive.com' => '\Embera\Providers\Indaco',
         'infogr.am' => '\Embera\Providers\Infogram',
+        'infogram.com' => '\Embera\Providers\Infogram',
         'instagram.com' => '\Embera\Providers\Instagram',
         'instagr.am' => '\Embera\Providers\Instagram',
         'issuu.com' => '\Embera\Providers\Issuu',

--- a/Lib/Embera/Providers/Infogram.php
+++ b/Lib/Embera/Providers/Infogram.php
@@ -21,7 +21,7 @@ namespace Embera\Providers;
 class Infogram extends \Embera\Adapters\Service
 {
     /** inline {@inheritdoc} */
-    protected $apiUrl = 'https://infogr.am/oembed/?format=json';
+    protected $apiUrl = 'https://infogram.com/oembed?format=json';
 
     /** inline {@inheritdoc} */
     protected function validateUrl()
@@ -29,9 +29,10 @@ class Infogram extends \Embera\Adapters\Service
         $this->url->convertToHttps();
         $this->url->stripQueryString();
         $this->url->stripLastSlash();
-        $this->url->invalidPattern('infogr\.am/(?:pricing|register|login|search|terms|privacy|featured|education|brands|organizations)$');
+        $this->url->stripWWW();
+        $this->url->invalidPattern('(infogr\.am|infogram\.com)/(?:pricing|register|login|search|terms|privacy|featured|education|brands|organizations)$');
 
-        return (preg_match('~infogr\.am/([^/ ]+)$~i', $this->url));
+        return (preg_match('~(infogr\.am|infogram\.com)/([^/ ]+)$~i', $this->url));
     }
 }
 

--- a/Tests/TestServiceInfogram.php
+++ b/Tests/TestServiceInfogram.php
@@ -22,6 +22,8 @@ class TestServiceInfogram extends TestProviders
             'http://infogr.am/12saeimas-velesanu-rezume?query-string',
             'https://infogr.am/the-2014-creative-jobs-report-fact-sheet/',
             'https://infogr.am/que_font_les_utilisateurs_de_google___en_',
+            'https://infogram.com/que_font_les_utilisateurs_de_google___en_',
+            'https://www.infogram.com/que_font_les_utilisateurs_de_google___en_',
         ),
         'invalid' => array(
             'https://infogr.am/featured',


### PR DESCRIPTION
Infogram has changed their domain.
They now use `infogram.com` instead of `infogr.am`.