### PR TITLE
Use already defined TRAVIS env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,16 @@
+dist: xenial
+os: linux
 language: php
-
-sudo: false
-dist: trusty
 
 php:
   - 7.2
   - 7.3
   - 7.4
 
-env:
-  - ONTRAVIS=1
-
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
-matrix:
-    fast_finish: true
-
-before_script:
-  - composer install
+before_script: composer install
 
 script: composer test

--- a/tests/Embera/Provider/DailyMotionTest.php
+++ b/tests/Embera/Provider/DailyMotionTest.php
@@ -49,7 +49,7 @@ final class DailyMotionTest extends ProviderTester
 
     public function testProvider()
     {
-        $travis = (bool) getenv('ONTRAVIS');
+        $travis = (bool) getenv('TRAVIS');
         if ($travis) {
             $this->markTestIncomplete('Disabling this provider since it seems to have problems with the endpoint (DailyMotion).');
         }

--- a/tests/Embera/Provider/HuluTest.php
+++ b/tests/Embera/Provider/HuluTest.php
@@ -34,7 +34,7 @@ final class HuluTest extends ProviderTester
 
     public function testProvider()
     {
-        $travis = (bool) getenv('ONTRAVIS');
+        $travis = (bool) getenv('TRAVIS');
         if ($travis) {
             $this->markTestIncomplete('Disabling this provider since it seems to have problems with the endpoint (OnSizzle).');
         }

--- a/tests/Embera/Provider/OnSizzleTest.php
+++ b/tests/Embera/Provider/OnSizzleTest.php
@@ -34,7 +34,7 @@ final class OnSizzleTest extends ProviderTester
 
     public function testProvider()
     {
-        $travis = (bool) getenv('ONTRAVIS');
+        $travis = (bool) getenv('TRAVIS');
         if ($travis) {
             $this->markTestIncomplete('Disabling this provider since it seems to have problems with the endpoint (OnSizzle).');
         }

--- a/tests/Embera/Provider/TheySaidSoTest.php
+++ b/tests/Embera/Provider/TheySaidSoTest.php
@@ -30,7 +30,7 @@ final class TheySaidSoTest extends ProviderTester
 
     public function testProvider()
     {
-        $travis = (bool) getenv('ONTRAVIS');
+        $travis = (bool) getenv('TRAVIS');
         if ($travis) {
             $this->markTestIncomplete('Disabling testing because provider seems to have stop providing oembed capabilities (TheySaidSo). If it continues to fail it will be deleted.');
         }

--- a/tests/Embera/Provider/TwitchTest.php
+++ b/tests/Embera/Provider/TwitchTest.php
@@ -31,7 +31,7 @@ final class TwitchTest extends ProviderTester
 
     public function testProvider()
     {
-        $travis = (bool) getenv('ONTRAVIS');
+        $travis = (bool) getenv('TRAVIS');
         if ($travis) {
             $this->markTestIncomplete('Disabling testing because provider seems to always return a 204 error code (Twitch). If it continues to fail it will be deleted.');
         }

--- a/tests/Embera/Provider/VliveTest.php
+++ b/tests/Embera/Provider/VliveTest.php
@@ -36,7 +36,7 @@ final class VliveTest extends ProviderTester
 
     public function testProvider()
     {
-        $travis = (bool) getenv('ONTRAVIS');
+        $travis = (bool) getenv('TRAVIS');
         if ($travis) {
             $this->markTestIncomplete('Travis doesnt like this provider (Vlive).');
             return ;


### PR DESCRIPTION
Instead of using a custom one.
See https://docs.travis-ci.com/user/environment-variables/#default-environment-variables

Also, update travis file:
- `matrix` with `fast_finish` is useless as there is no `allow_failures`
- `sudo: false` is now deprecated and useless
- use latest distribution instead of the legacy `trusty`
- use a better way to cache packagist stuff (because metadata change to often and invalid the travis cache for nothing)