### PR TITLE
Fix Embera\Html namespace definitions

### DIFF
--- a/src/Embera/Html/IgnoreTags.php
+++ b/src/Embera/Html/IgnoreTags.php
@@ -10,7 +10,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Embera\html;
+namespace Embera\Html;
 
 /**
  * This Class is in charge of replacing content, ignoring specific

--- a/src/Embera/Html/ResponsiveEmbeds.php
+++ b/src/Embera/Html/ResponsiveEmbeds.php
@@ -10,7 +10,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Embera\html;
+namespace Embera\Html;
 
 /**
  * Class Responsable of converting html into responsive html.


### PR DESCRIPTION
Fix composer warnings:

`composer.phar install -o` output

```
Generating optimized autoload files
Deprecation Notice: Class Embera\html\IgnoreTags located in ./src/Embera/Html/IgnoreTags.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in composer.phar/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Embera\html\ResponsiveEmbeds located in ./src/Embera/Html/ResponsiveEmbeds.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in composer.phar/src/Composer/Autoload/ClassMapGenerator.php:201
```