### PR TITLE
New Facebook and Instagram endpoints

### DIFF
--- a/src/Embera/Provider/Facebook.php
+++ b/src/Embera/Provider/Facebook.php
@@ -29,7 +29,7 @@ class Facebook extends ProviderAdapter implements ProviderInterface
     ];
 
     /** inline {@inheritdoc} */
-    protected $allowedParams = [ 'maxwidth', 'maxheight', 'callback', 'omitscript' ];
+    protected $allowedParams = [ 'maxwidth', 'maxheight', 'callback', 'omitscript', 'breaking_change' ];
 
     /** inline {@inheritdoc} */
     protected $httpsSupport = true;

--- a/src/Embera/Provider/Facebook.php
+++ b/src/Embera/Provider/Facebook.php
@@ -20,8 +20,10 @@ use Embera\Url;
  */
 class Facebook extends ProviderAdapter implements ProviderInterface
 {
+    protected $legacyEndpoint = 'https://apps.facebook.com/plugins/{type}/oembed.json';
+    
     /** inline {@inheritdoc} */
-    protected $endpoint = 'https://apps.facebook.com/plugins/{type}/oembed.json';
+    protected $endpoint = 'https://graph.facebook.com/v8.0/oembed_{type}';
 
     /** inline {@inheritdoc} */
     protected static $hosts = [
@@ -126,16 +128,27 @@ class Facebook extends ProviderAdapter implements ProviderInterface
     /** inline {@inheritdoc} */
     public function getEndpoint()
     {
+        if (isset($this->config['access_token'])) {
+            if ($this->urlMatchesPattern($this->url, $this->videoPatterns)) {
+                $type = 'videos';
+            } elseif ($this->urlMatchesPattern($this->url, $this->postPatterns)) {
+                $type = 'post';
+            } else {
+                $type = 'page';
+            }
 
-        if ($this->urlMatchesPattern($this->url, $this->videoPatterns)) {
-            $type = 'video';
-        } elseif ($this->urlMatchesPattern($this->url, $this->postPatterns)) {
-            $type = 'post';
+            return str_replace('{type}', $type, $this->endpoint);            
         } else {
-            $type = 'page';
-        }
+            if ($this->urlMatchesPattern($this->url, $this->videoPatterns)) {
+                $type = 'video';
+            } elseif ($this->urlMatchesPattern($this->url, $this->postPatterns)) {
+                $type = 'post';
+            } else {
+                $type = 'page';
+            }
 
-        return str_replace('{type}', $type, $this->endpoint);
+            return str_replace('{type}', $type, $this->legacyEndpoint);
+        }
     }
 
     /** inline {@inheritdoc} */

--- a/src/Embera/Provider/Facebook.php
+++ b/src/Embera/Provider/Facebook.php
@@ -31,7 +31,7 @@ class Facebook extends ProviderAdapter implements ProviderInterface
     ];
 
     /** inline {@inheritdoc} */
-    protected $allowedParams = [ 'maxwidth', 'maxheight', 'callback', 'omitscript', 'breaking_change', 'access_token' ];
+    protected $allowedParams = [ 'maxwidth', 'maxheight', 'callback', 'omitscript', 'breaking_change', 'access_token', 'fields' ];
 
     /** inline {@inheritdoc} */
     protected $httpsSupport = true;

--- a/src/Embera/Provider/Facebook.php
+++ b/src/Embera/Provider/Facebook.php
@@ -31,7 +31,7 @@ class Facebook extends ProviderAdapter implements ProviderInterface
     ];
 
     /** inline {@inheritdoc} */
-    protected $allowedParams = [ 'maxwidth', 'maxheight', 'callback', 'omitscript', 'breaking_change' ];
+    protected $allowedParams = [ 'maxwidth', 'maxheight', 'callback', 'omitscript', 'breaking_change', 'access_token' ];
 
     /** inline {@inheritdoc} */
     protected $httpsSupport = true;

--- a/src/Embera/Provider/Instagram.php
+++ b/src/Embera/Provider/Instagram.php
@@ -31,7 +31,7 @@ class Instagram extends ProviderAdapter implements ProviderInterface
     ];
 
     /** inline {@inheritdoc} */
-    protected $allowedParams = [ 'maxwidth', 'maxheight', 'callback', 'omitscript', 'breaking_change', 'access_token' ];
+    protected $allowedParams = [ 'maxwidth', 'maxheight', 'callback', 'omitscript', 'breaking_change', 'access_token', 'fields' ];
     
     /** inline {@inheritdoc} */
     protected $httpsSupport = true;

--- a/src/Embera/Provider/Instagram.php
+++ b/src/Embera/Provider/Instagram.php
@@ -20,8 +20,10 @@ use Embera\Url;
  */
 class Instagram extends ProviderAdapter implements ProviderInterface
 {
+    protected $legacyEndpoint = 'https://api.instagram.com/oembed/?format=json';
+
     /** inline {@inheritdoc} */
-    protected $endpoint = 'https://api.instagram.com/oembed/?format=json';
+    protected $endpoint = 'https://graph.facebook.com/v8.0/instagram_oembed';
 
     /** inline {@inheritdoc} */
     protected static $hosts = [
@@ -29,7 +31,7 @@ class Instagram extends ProviderAdapter implements ProviderInterface
     ];
 
     /** inline {@inheritdoc} */
-    protected $allowedParams = [ 'maxwidth', 'maxheight', 'callback', 'omitscript', 'breaking_change' ];
+    protected $allowedParams = [ 'maxwidth', 'maxheight', 'callback', 'omitscript', 'breaking_change', 'access_token' ];
     
     /** inline {@inheritdoc} */
     protected $httpsSupport = true;
@@ -46,6 +48,16 @@ class Instagram extends ProviderAdapter implements ProviderInterface
         );
     }
 
+    /** inline {@inheritdoc} */
+    public function getEndpoint()
+    {
+        if (isset($this->config['access_token'])) {
+            return $this->endpoint;
+        } else {
+            return $this->legacyEndpoint;
+        }
+    }
+    
     /** inline {@inheritdoc} */
     public function normalizeUrl(Url $url)
     {

--- a/src/Embera/Provider/Instagram.php
+++ b/src/Embera/Provider/Instagram.php
@@ -29,6 +29,9 @@ class Instagram extends ProviderAdapter implements ProviderInterface
     ];
 
     /** inline {@inheritdoc} */
+    protected $allowedParams = [ 'maxwidth', 'maxheight', 'callback', 'omitscript', 'breaking_change' ];
+    
+    /** inline {@inheritdoc} */
     protected $httpsSupport = true;
 
     /** inline {@inheritdoc} */


### PR DESCRIPTION
According to [Facebook documentation](https://developers.facebook.com/docs/plugins/oembed) and [Instagram documentation](https://developers.facebook.com/docs/instagram/oembed) current endpoint will be functional only until October 24, 2020.

This PR introduces new endpoints, which requires access_token. To keep backward compatibility, if no access token is provided in Embera config, legacy endpoint is used. Note, that for access token could be used combination of {app_id}|{app_secret} (see [here](https://developers.facebook.com/docs/facebook-login/access-tokens#apptokens)).