### PR TITLE
Use correct Facebook endpoint for videos

### DIFF
--- a/src/Embera/Provider/Facebook.php
+++ b/src/Embera/Provider/Facebook.php
@@ -130,7 +130,7 @@ class Facebook extends ProviderAdapter implements ProviderInterface
     {
         if (isset($this->config['access_token'])) {
             if ($this->urlMatchesPattern($this->url, $this->videoPatterns)) {
-                $type = 'videos';
+                $type = 'video';
             } elseif ($this->urlMatchesPattern($this->url, $this->postPatterns)) {
                 $type = 'post';
             } else {


### PR DESCRIPTION
When using an `access_token`, the endpoint for Facebook videos is generated incorrectly because the type variable was set to `videos` (plural) instead of `video`. 
Note that the [Facebook documentation](https://developers.facebook.com/docs/plugins/oembed/) also has a typo. At the top of the page under *Endpoints* they correctly indicate the endpoint as `/oembed_video` but towards the end of the page under *Getting Embed HTML* they incorrectly specify `/oembed_videos`. Only `/oembed_video` works, based on my testing.