### PR TITLE
fix: use current `__NAMESPACE__` instead of hardcoded string

### DIFF
--- a/src/Embera/ProviderCollection/ProviderCollectionAdapter.php
+++ b/src/Embera/ProviderCollection/ProviderCollectionAdapter.php
@@ -100,7 +100,7 @@ abstract class ProviderCollectionAdapter implements ProviderCollectionInterface
     {
         foreach ((array) $names as $name) {
             if ($prefix) {
-                $name = 'Embera\Provider\\' . $name;
+                $name = self::getProviderClassFqn($name);
             }
 
             $hosts = $name::getHosts();
@@ -190,7 +190,7 @@ abstract class ProviderCollectionAdapter implements ProviderCollectionInterface
     protected function initializeProvider($class, $url)
     {
         if (strpos($class, '\\') === false) {
-            $class = 'Embera\Provider\\' . $class;
+            $class = self::getProviderClassFqn($class);
         }
 
         $reflection = new ReflectionClass($class);
@@ -202,6 +202,21 @@ abstract class ProviderCollectionAdapter implements ProviderCollectionInterface
         }
 
         return $provider;
+    }
+    
+    /**
+     * Get the full qualified class name for a given provider name. E.g. `YouTube` => `Embera\Provider\YouTube`
+     *
+     * @param string $name
+     * @return string
+     */
+    public static function getProviderClassFqn($name)
+    {
+        $providerFqn = explode('\\', __NAMESPACE__);
+        array_pop($providerFqn);
+        $providerFqn[] = 'Provider';
+        $providerFqn[] = $name;
+        return join('\\', $providerFqn);
     }
 
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Use the `__NAMESPACE__` identifier to get the full qualified name for a class instead of a string.

## What problem is this fixing?

I want to bundle this package within my WordPress plugin together with [PHP-Scoper](https://github.com/humbug/php-scoper), unfortunately it does not scope a hardcoded namespace string.

> PHP-Scoper is a tool which essentially moves any body of code, including all dependencies such as vendor directories, to a new and distinct namespace.

WIthout this changes, I get the following error:

```
PHP Fatal error:  Uncaught Error: Class 'Embera\\Provider\\TwentyThreeHq' not found in X/vendor/mpratt/embera/src/Embera/ProviderCollection/ProviderCollectionAdapter.php:89
```