### PR TITLE
fix: playlist API URL support for SoundCloud

### DIFF
--- a/src/Embera/Provider/SoundCloud.php
+++ b/src/Embera/Provider/SoundCloud.php
@@ -28,7 +28,8 @@ class SoundCloud extends ProviderAdapter implements ProviderInterface
 
     /** inline {@inheritdoc} */
     protected static $hosts = [
-        'soundcloud.com'
+        'soundcloud.com',
+        'api.soundcloud.com'
     ];
 
     /** inline {@inheritdoc} */


### PR DESCRIPTION
The oEmbed provder of SoundCloud also supports playlist URLs from `api.soundcloud.com`:

Reproduce:

1. Navigate to https://soundcloud.com/search/sets?q=playlist
1. Pick any playlist, e.g. https://soundcloud.com/billieeilish/sets/playlist
1. Click on share and copy the "Embed" code

The embed code looks like this:

```html
<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/336397030&color=%23ff5500&auto_play=true&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe><div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;"><a href="https://soundcloud.com/billieeilish" title="Billie Eilish" target="_blank" style="color: #cccccc; text-decoration: none;">Billie Eilish</a> · <a href="https://soundcloud.com/billieeilish/sets/playlist" title="playlist" target="_blank" style="color: #cccccc; text-decoration: none;">playlist</a></div>
```

From the embed URL we can extract the API url `https://api.soundcloud.com/playlists/336397030` and pass it to the oEmbed provider:

https://soundcloud.com/oembed?format=json&url=https://api.soundcloud.com/playlists/336397030

![image](https://user-images.githubusercontent.com/1008534/165275313-8e0f6b6b-25ad-4bbd-adf4-005886941992.png)
