### PR TITLE
fix: compatibility with private SoundCloud embeds and security token

### DIFF
--- a/src/Embera/Provider/SoundCloud.php
+++ b/src/Embera/Provider/SoundCloud.php
@@ -51,7 +51,6 @@ class SoundCloud extends ProviderAdapter implements ProviderInterface
     public function normalizeUrl(Url $url)
     {
         $url->convertToHttps();
-        $url->removeQueryString();
         $url->removeLastSlash();
 
         return $url;


### PR DESCRIPTION
Track: https://soundcloud.com/matthias-guenter-745578676/sample-private-audio-for-testing-purposes

Embed Code:

```html
<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1303723630%3Fsecret_token%3Ds-qVs8eTtFFwv&color=%23ff5500&auto_play=true&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe><div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;"><a href="https://soundcloud.com/matthias-guenter-745578676" title="Matthias Günter" target="_blank" style="color: #cccccc; text-decoration: none;">Matthias Günter</a> · <a href="https://soundcloud.com/matthias-guenter-745578676/sample-private-audio-for-testing-purposes/s-qVs8eTtFFwv" title="Sample Private Audio for Testing Purposes" target="_blank" style="color: #cccccc; text-decoration: none;">Sample Private Audio for Testing Purposes</a></div>
```

Extracted URL for oEmbed:

```
https://api.soundcloud.com/tracks/1303723630?secret_token=s-qVs8eTtFFwv
```

oEmbed call without token:

```
https://soundcloud.com/oembed?url=https://api.soundcloud.com/tracks/1303723630

HTTP Error 404
```

oEmbed call with token:

```
https://soundcloud.com/oembed?url=https://api.soundcloud.com/tracks/1303723630?secret_token=s-qVs8eTtFFwv

<?xml version="1.0" encoding="UTF-8"?>
<oembed>
  <version type="float">1.0</version>
  <type>rich</type>
  <provider-name>SoundCloud</provider-name>
  <provider-url>https://soundcloud.com</provider-url>
  <height type="integer">400</height>
  <width>100%</width>
  <title>Sample Private Audio for Testing Purposes by Matthias Günter</title>
  <description></description>
  <thumbnail-url>https://soundcloud.com/images/fb_placeholder.png</thumbnail-url>
  <html>&lt;iframe width="100%" height="400" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?visual=true&amp;url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F1303723630&amp;show_artwork=true&amp;secret_token=s-qVs8eTtFFwv"&gt;&lt;/iframe&gt;</html>
  <author-name>Matthias Günter</author-name>
  <author-url>https://soundcloud.com/matthias-guenter-745578676</author-url>
</oembed>
```

The current SoundCloud provider removes all query strings, which should not be the case for the `secret_token`.