### PR TITLE
Added fake response support for Vimeo

### DIFF
--- a/doc/providers/Vimeo.md
+++ b/doc/providers/Vimeo.md
@@ -10,7 +10,7 @@ teams, and organizations who use Vi...
 Name: Vimeo
 - Documentation: NONE
 - HTTPS support: YES
-- Fake Response: NO
+- Fake Response: YES
 - Oembed Params: autopause , autopip , autoplay , background , byline , color , controls , dnt , keyboard , loop , muted , pip , playsinline , portrait , quality , responsive , speed , texttrack , title , transparent
 - Supported Hosts: vimeo.com
 - Responsive response: NO

--- a/src/Embera/Provider/Vimeo.php
+++ b/src/Embera/Provider/Vimeo.php
@@ -62,7 +62,34 @@ class Vimeo extends ProviderAdapter implements ProviderInterface
         $url->removeQueryString();
         $url->removeLastSlash();
 
+		if (preg_match('~(?:vimeo\.com/|player\.vimeo\.com/video/)(\d+)~i', (string) $url, $matches)) {
+			$url->overwrite('https://player.vimeo.com/video/' . $matches[1]);
+		}
+
         return $url;
     }
+
+	/** inline {@inheritdoc} */
+	public function getFakeResponse()
+	{
+        preg_match('/(?:https?:\/\/)?(?:www\.)?(?:vimeo\.com\/(?:video\/)?)?([0-9]+)(?:[a-zA-Z0-9_-]+)?/', (string) $this->url, $matches);
+        $embedUrl = 'https://player.vimeo.com/video/' . $matches['1'];
+
+		$attr = [];
+		$attr[] = 'src="' . $embedUrl . '"';
+		$attr[] = 'width="{width}"';
+		$attr[] = 'height="{height}"';
+		$attr[] = 'frameborder="0"';
+		$attr[] = 'allow="autoplay; fullscreen; picture-in-picture"';
+		$attr[] = 'allowfullscreen';
+
+		return [
+			'type' => 'video',
+			'provider_name' => 'Vimeo',
+			'provider_url' => 'https://vimeo.com',
+			'title' => 'Unknown title',
+			'html' => '<iframe ' . implode(' ', $attr). '></iframe>',
+		];
+	}
 
 }

--- a/tests/Embera/Provider/VimeoTest.php
+++ b/tests/Embera/Provider/VimeoTest.php
@@ -22,12 +22,20 @@ final class VimeoTest extends ProviderTester
     protected $tasks = [
         'valid_urls' => [
             'https://vimeo.com/375646424',
-            'https://vimeo.com/374131624',
-            'https://vimeo.com/374131624',
+            'https://vimeo.com/491313737',
+            'https://vimeo.com/583870374',
         ],
         'invalid_urls' => [
             'https://vimeo.com/',
+            'https://vimeo.com/video',
         ],
+		'normalize_urls' => [
+            'http://vimeo.com/groups/shortfilms/videos/66185763' => 'https://vimeo.com/groups/shortfilms/videos/66185763',
+        ],
+        'fake_response' => [
+            'type' => 'video',
+            'html' => '<iframe'
+		]
     ];
 
     public function testProvider()


### PR DESCRIPTION
There was not "fake response" support for Vimeo, I added it by respecting the code which was used on other providers