### PR TITLE
Fix Rumble

### DIFF
--- a/src/Embera/Provider/Rumble.php
+++ b/src/Embera/Provider/Rumble.php
@@ -35,19 +35,18 @@ class Rumble extends ProviderAdapter implements ProviderInterface
     protected $httpsSupport = true;
 
     /** inline {@inheritdoc} */
-    protected $responsiveSupport = false;
+    protected $responsiveSupport = true;
 
     /** inline {@inheritdoc} */
     public function validateUrl(Url $url)
     {
-        return (bool) (preg_match('~rumble\.com/([^/]+)\.html$~i', (string) $url));
+        return (bool) (preg_match('~rumble\.com/embed/([^/]+)~i', (string) $url));
     }
 
     /** inline {@inheritdoc} */
     public function normalizeUrl(Url $url)
     {
         $url->convertToHttps();
-        $url->removeQueryString();
         $url->removeLastSlash();
 
         return $url;


### PR DESCRIPTION
This is probably not the correct fix, but it does solve some immediate issues. Documentation for Rumble oembed use is pretty nonexistent.

Rumble docs use `https://rumble.com/embed/v6uz6v/?pub=7&rel=5&autoplay=2` for an example of an iframe embed. These changes allow this url form to be found and works.