### PR TITLE
fix: Token in unlisted Vimeo URLs being stripped by URL normalizer

### DIFF
--- a/src/Embera/Provider/Vimeo.php
+++ b/src/Embera/Provider/Vimeo.php
@@ -63,7 +63,7 @@ class Vimeo extends ProviderAdapter implements ProviderInterface
         $url->removeQueryString();
         $url->removeLastSlash();
 
-        if (preg_match('~(?:vimeo\.com/|player\.vimeo\.com/video/)(\d+)~i', (string) $url, $matches)) {
+        if (preg_match('~(?:vimeo\.com/|player\.vimeo\.com/video/)(\d+)/?$~i', (string) $url, $matches)) {
             $url->overwrite('https://player.vimeo.com/video/' . $matches[1]);
         }
 

--- a/tests/Embera/Provider/VimeoTest.php
+++ b/tests/Embera/Provider/VimeoTest.php
@@ -29,17 +29,18 @@ final class VimeoTest extends ProviderTester
             'https://vimeo.com/',
             'https://vimeo.com/video',
         ],
-		'normalize_urls' => [
+        'normalize_urls' => [
             'http://vimeo.com/groups/shortfilms/videos/66185763' => 'https://vimeo.com/groups/shortfilms/videos/66185763',
+            'https://vimeo.com/919781633/aaaaaaaaaa' => 'https://vimeo.com/919781633/aaaaaaaaaa',
         ],
         'fake_response' => [
             'type' => 'video',
             'html' => '<iframe'
-		]
+        ]
     ];
 
     public function testProvider()
     {
-        $this->validateProvider('Vimeo', [ 'width' => 480, 'height' => 270]);
+        $this->validateProvider('Vimeo', ['width' => 480, 'height' => 270]);
     }
 }


### PR DESCRIPTION
Hi,

Unlisted videos on Vimeo have a URL like `https://vimeo.com/919781633/1a2b3c4d5e` where 1a2b3c4d5e is what I refer to as the "privacy token".

*(Note: I am unable to provide an actual unlisted video URL; I only have my client's which I cannot share. The example I gave above works with or without the token on the end. The actual unlisted video I have will not.)*

The Vimeo provider is normalizing this to `https://player.vimeo.com/video/919781633`, effectively stripping the privacy token and preventing the OEmbed lookup from fetching information.

This PR makes the URL normalizer stricter, so it won't normalize URLs that have additional data after the video ID.