### PR TITLE
Add support for YouTube Live URLs

### DIFF
--- a/src/Embera/Provider/Youtube.php
+++ b/src/Embera/Provider/Youtube.php
@@ -40,7 +40,8 @@ class Youtube extends ProviderAdapter implements ProviderInterface
         return (bool) (
             preg_match('~v=(?:[a-z0-9_\-]+)~i', (string) $url) ||
             preg_match('~/shorts/(?:[a-z0-9_\-]+)~i', (string) $url) ||
-            preg_match('~/playlist(.+)list=(?:[a-z0-9_\-]+)~i', (string) $url)
+            preg_match('~/playlist(.+)list=(?:[a-z0-9_\-]+)~i', (string) $url) ||
+            preg_match('~/live/(?:[a-z0-9_\-]+)~i', (string) $url)
         );
     }
 

--- a/tests/Embera/Provider/YoutubeTest.php
+++ b/tests/Embera/Provider/YoutubeTest.php
@@ -31,6 +31,8 @@ final class YoutubeTest extends ProviderTester
             'http://youtu.be/mghhLqu31cQ',
             'http://www.youtube.com/playlist?list=PLSL0f2Dh_snCsLgQ3J319RYQyctRlfJFc',
             'https://www.youtube.com/shorts/a12CpYea0i4',
+            'https://youtube.com/live/f1J38FlDKxo',
+            'https://www.youtube.com/live/f1J38FlDKxo',
         ),
         'invalid_urls' => array(
             'http://youtube.com/watch?list=hi',


### PR DESCRIPTION
The YouTube provider currently is not handling YouTube Live URLs like this one of the Apple event: `https://www.youtube.com/live/f1J38FlDKxo`

This PR fixes that.