### PR TITLE
Additional Podbean URL formats

### DIFF
--- a/src/Embera/Provider/Podbean.php
+++ b/src/Embera/Provider/Podbean.php
@@ -40,7 +40,7 @@ class Podbean extends ProviderAdapter implements ProviderInterface
     /** inline {@inheritdoc} */
     public function validateUrl(Url $url)
     {
-        return (bool) (preg_match('~podbean\.com/e/([^/]+)$~i', (string) $url));
+        return (bool) (preg_match('~podbean\.com/(?:e|eas|media/share)/([^/]+)$~i', (string) $url));
     }
 
     /** inline {@inheritdoc} */

--- a/tests/Embera/Provider/PodbeanTest.php
+++ b/tests/Embera/Provider/PodbeanTest.php
@@ -23,6 +23,8 @@ final class PodbeanTest extends ProviderTester
         'valid_urls' => [
             'https://podcast.podbean.com/e/jen-and-vernon-chat-podcast-resolutions-twitter-advice-and-predictions-for-2019/',
             'https://pretaporter.podbean.com/e/pret-a-porter-dos-bastidores-a-passarela-da-modalisboa-collective/',
+            'https://www.podbean.com/eas/pb-ab123-1234567',
+            'https://www.podbean.com/media/share/pb-abcde-1234567',
         ],
         'invalid_urls' => [
             'https://podcast.podbean.com/',


### PR DESCRIPTION
We have a client with (I assume) a Podbean permalink in the form of https://www.podbean.com/eas/pb-abcde-1234567. It redirects to a media share URL like https://www.podbean.com/media/share/pb-abcde-1234567.

Their OEmbed API accepts either format. This PR expands the Podbean URL validation to accept both forms.