### PR TITLE
Fix PHP 8.4 deprecation warning for implicitly nullable parameter

### DIFF
--- a/src/Embera/Embera.php
+++ b/src/Embera/Embera.php
@@ -62,7 +62,7 @@ class Embera
      * @param HttpClientInterface $httpClient
      * @return void
      */
-    public function __construct(array $config = [], ProviderCollectionInterface $collection = null, HttpClientInterface $httpClient = null)
+    public function __construct(array $config = [], ?ProviderCollectionInterface $collection = null, ?HttpClientInterface $httpClient = null)
     {
         $this->config = array_merge([
             'https_only' => false,


### PR DESCRIPTION
Deprecated: Embera\Embera::__construct(): Implicitly marking parameter $collection as nullable is deprecated