### PR TITLE
Add php 8.3 compatibility / update php required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "ext-json": "*"
     },
     "require-dev": {

--- a/src/Embera/Embera.php
+++ b/src/Embera/Embera.php
@@ -62,7 +62,7 @@ class Embera
      * @param HttpClientInterface $httpClient
      * @return void
      */
-    public function __construct(array $config = [], ProviderCollectionInterface $collection = null, HttpClientInterface $httpClient = null)
+    public function __construct(array $config = [], ?ProviderCollectionInterface $collection = null, ?HttpClientInterface $httpClient = null)
     {
         $this->config = array_merge([
             'https_only' => false,


### PR DESCRIPTION
I would think it should be safe to drop php 5.6 support. This small change fixes a deprecation error as of 8.3